### PR TITLE
Renamed inconsistent identifiers

### DIFF
--- a/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollLayoutManager.java
+++ b/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollLayoutManager.java
@@ -155,16 +155,16 @@ class DiscreteScrollLayoutManager extends RecyclerView.LayoutManager {
     }
 
     private void layoutView(RecyclerView.Recycler recycler, int position, Point viewCenter) {
-        View v = detachedCache.get(position);
-        if (v == null) {
-            v = recycler.getViewForPosition(position);
-            addView(v);
-            measureChildWithMargins(v, 0, 0);
-            layoutDecoratedWithMargins(v,
+        View viewToMeasure = detachedCache.get(position);
+        if (viewToMeasure == null) {
+            viewToMeasure = recycler.getViewForPosition(position);
+            addView(viewToMeasure);
+            measureChildWithMargins(viewToMeasure, 0, 0);
+            layoutDecoratedWithMargins(viewToMeasure,
                     viewCenter.x - childHalfWidth, viewCenter.y - childHalfHeight,
                     viewCenter.x + childHalfWidth, viewCenter.y + childHalfHeight);
         } else {
-            attachView(v);
+            attachView(viewToMeasure);
             detachedCache.remove(position);
         }
     }
@@ -329,9 +329,9 @@ class DiscreteScrollLayoutManager extends RecyclerView.LayoutManager {
             scrolled = 0;
         }
 
-        Direction scrollDirection = Direction.fromDelta(scrolled);
+        Direction direction = Direction.fromDelta(scrolled);
         if (Math.abs(scrolled) == scrollToChangeCurrent) {
-            currentPosition += scrollDirection.applyTo(1);
+            currentPosition += direction.applyTo(1);
             scrolled = 0;
         }
 
@@ -360,8 +360,8 @@ class DiscreteScrollLayoutManager extends RecyclerView.LayoutManager {
             scrolled -= scrolledPositions * scrollToChangeCurrent;
         }
         if (isAnotherItemCloserThanCurrent()) {
-            Direction direction = Direction.fromDelta(scrolled);
-            currentPosition += direction.applyTo(1);
+            Direction scrollDirection = Direction.fromDelta(scrolled);
+            currentPosition += scrollDirection.applyTo(1);
             scrolled = -getHowMuchIsLeftToScroll(scrolled);
         }
         pendingPosition = NO_POSITION;

--- a/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollView.java
+++ b/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollView.java
@@ -132,21 +132,21 @@ public class DiscreteScrollView extends RecyclerView {
 
         @Override
         public void onScrollEnd() {
-            ViewHolder holder = null;
-            int current = layoutManager.getCurrentPosition();
+            ViewHolder currentHolder = null;
+            int currentHolder = layoutManager.getCurrentPosition();
             if (scrollStateChangeListener != null) {
-                holder = getViewHolder(current);
+                holder = getViewHolder(currentHolder);
                 if (holder == null) {
                     return;
                 }
-                scrollStateChangeListener.onScrollEnd(holder, current);
+                scrollStateChangeListener.onScrollEnd(holder, currentHolder);
             }
             if (onItemChangedListener != null) {
                 if (holder == null) {
-                    holder = getViewHolder(current);
+                    holder = getViewHolder(currentHolder);
                 }
                 if (holder != null) {
-                    onItemChangedListener.onCurrentItemChanged(holder, current);
+                    onItemChangedListener.onCurrentItemChanged(holder, currentHolder);
                 }
             }
         }
@@ -172,9 +172,9 @@ public class DiscreteScrollView extends RecyclerView {
         public void onCurrentViewFirstLayout() {
             if (onItemChangedListener != null) {
                 int current = layoutManager.getCurrentPosition();
-                ViewHolder currentHolder = getViewHolder(current);
-                if (currentHolder != null) {
-                    onItemChangedListener.onCurrentItemChanged(currentHolder, current);
+                ViewHolder holder = getViewHolder(current);
+                if (holder != null) {
+                    onItemChangedListener.onCurrentItemChanged(holder, current);
                 }
             }
         }


### PR DESCRIPTION
I used an automatic tool which suggests useful renaming operations based on the frequency such names appear in the code-base. For example, "viewToMeasure" appears more frequently than "v" in the context in which "v" is used, so I renamed it. I did not modify functional parts of the code, I just applied such renamings.