### PR TITLE
Added feature to allow sliding of multiple views on fling gesture.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+I have forked this library to add a feature to allow sliding of multiples view on fling gesture. The original library only used to move view one-by-one. To use this feature set 
+
+    setSlideOnFling(true);
+    
+The default threshold is set to integer 2100. Lower the threshold, more fluid the animation. To change the threshold use
+
+    setSlideOnFlingThreshold(value);
+
+
+
+
+
 # DiscreteScrollView
 
 The library is a RecyclerView-based implementation of a scrollable list, where current item is centered and can be changed using swipes.
@@ -8,6 +20,8 @@ It is similar to a ViewPager, but you can quickly and painlessly create layout, 
 ## Gradle 
 Add this into your dependencies block.
 ```
+//Please remember this gradle will use the original library and not my version of it. 
+//If you want to use my version, import it as moudle and use it in your project
 compile 'com.yarolegovich:discrete-scrollview:1.2.0'
 ```
 

--- a/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollView.java
+++ b/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollView.java
@@ -104,6 +104,14 @@ public class DiscreteScrollView extends RecyclerView {
         layoutManager.setTimeForItemSettle(millis);
     }
 
+    public void setSlideOnFling(Boolean result){
+        layoutManager.setShouldSlideOnFling(result);
+    }
+
+    public void setSlideOnFlingThreshold(int threshold){
+        layoutManager.setSlideOnFlingThreshold(threshold);
+    }
+
     public void setOrientation(Orientation orientation) {
         layoutManager.setOrientation(orientation);
     }


### PR DESCRIPTION
Use `picker.setSlideOnFling(true)` to use it. Default threshold set to `2100` which can dynamically be set by user using `picker.setSlideOnFlingThreshold(value)`. Lower the threshold, more fluid the animation. 

The DEFAULT_TIME_FOR_ITEM_SETTLE is set to 300 millis to provide smoother transition that look realistic. 