### PR TITLE
Fail to set null on recyclerview adapter

### DIFF
--- a/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollLayoutManager.java
+++ b/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollLayoutManager.java
@@ -475,7 +475,7 @@ class DiscreteScrollLayoutManager extends RecyclerView.LayoutManager {
 
     @Override
     public void onAdapterChanged(RecyclerView.Adapter oldAdapter, RecyclerView.Adapter newAdapter) {
-        if (newAdapter.getItemCount() > 0) {
+        if ((newAdapter != null) && (newAdapter.getItemCount() > 0)) {
             pendingPosition = NO_POSITION;
             scrolled = pendingScroll = 0;
             currentPosition = 0;


### PR DESCRIPTION
I follow this document https://github.com/airbnb/epoxy/wiki/Avoiding-Memory-Leaks to set `recyclerView.setAdapter(null);` in a fragment's onDestroyView method, but app crash when using `DiscreteScrollView recyclerView;`.