### PR TITLE
Fix: Given null Adapter would raise NullPointerException. However, the internal layout states should always be reset when new Adapter is set.

### DIFF
--- a/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollLayoutManager.java
+++ b/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollLayoutManager.java
@@ -467,11 +467,10 @@ class DiscreteScrollLayoutManager extends RecyclerView.LayoutManager {
 
     @Override
     public void onAdapterChanged(RecyclerView.Adapter oldAdapter, RecyclerView.Adapter newAdapter) {
-        if (newAdapter.getItemCount() > 0) {
-            pendingPosition = NO_POSITION;
-            scrolled = pendingScroll = 0;
-            currentPosition = 0;
-        }
+        pendingPosition = NO_POSITION;
+        scrolled = pendingScroll = 0;
+        currentPosition = 0;
+
         removeAllViews();
     }
 


### PR DESCRIPTION
Hi @yarolegovich ,

The `onAdapterChanged` is called when the Adapter is set to null, and the `NullPointerException` is raised. **The reason of setting null adapter is because the `RecyclerView` doesn't unset the adapter when it is detached from the parent View. In this case, if you have cyclic reference (the view knows the adapter and the adapter knows the view), you will notice the `ViewHolder` is leaked. The ViewHolder references to View and the View might maintain a Bitmap resource. That would introduce a killing memory leak.**

I noticed the leaking problem of using the RecyclerView in the AirBnb's Epoxy project, and they tackle the problem by unsetting the null adapter in the destruction flow. There is a StackOverflow thread talking about this, [link](https://stackoverflow.com/questions/35520946/leak-canary-recyclerview-leaking-madapter).

Related PR, https://github.com/yarolegovich/DiscreteScrollView/pull/51