### PR TITLE
Changes to InfiniteScrollAdapter

### DIFF
--- a/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollLayoutManager.java
+++ b/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollLayoutManager.java
@@ -573,7 +573,11 @@ class DiscreteScrollLayoutManager extends RecyclerView.LayoutManager {
     public void onAdapterChanged(RecyclerView.Adapter oldAdapter, RecyclerView.Adapter newAdapter) {
         pendingPosition = NO_POSITION;
         scrolled = pendingScroll = 0;
-        currentPosition = 0;
+        if (newAdapter instanceof InitialPositionProvider) {
+            currentPosition = ((InitialPositionProvider) newAdapter).getInitialPosition();
+        } else {
+            currentPosition = 0;
+        }
         recyclerViewProxy.removeAllViews();
     }
 
@@ -776,4 +780,7 @@ class DiscreteScrollLayoutManager extends RecyclerView.LayoutManager {
         void onDataSetChangeChangedPosition();
     }
 
+    public interface InitialPositionProvider {
+        int getInitialPosition();
+    }
 }


### PR DESCRIPTION
Do not use "sliding range" to simulate infinite scroll. I suppose that calls to resetRange() during the scroll were sometimes causing temporary issues with current position calculations when there were too few items in the adapter.

closes #125