### PR TITLE
Resizing whole recycler with no views removing and inflating.

### DIFF
--- a/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollLayoutManager.java
+++ b/library/src/main/java/com/yarolegovich/discretescrollview/DiscreteScrollLayoutManager.java
@@ -112,10 +112,9 @@ class DiscreteScrollLayoutManager extends RecyclerView.LayoutManager {
         //won't be cleared until onLayoutCompleted
         if (!isFirstOrEmptyLayout) {
             isFirstOrEmptyLayout = recyclerViewProxy.getChildCount() == 0;
-            if (isFirstOrEmptyLayout) {
-                initChildDimensions(recycler);
-            }
         }
+
+        initChildDimensions(recycler);
 
         recyclerViewProxy.detachAndScrapAttachedViews(recycler);
 
@@ -145,7 +144,7 @@ class DiscreteScrollLayoutManager extends RecyclerView.LayoutManager {
     }
 
     protected void initChildDimensions(RecyclerView.Recycler recycler) {
-        View viewToMeasure = recyclerViewProxy.getMeasuredChildForAdapterPosition(0, recycler);
+        View viewToMeasure = recyclerViewProxy.getMeasuredChildForAdapterPosition(currentPosition, recycler);
 
         int childViewWidth = recyclerViewProxy.getMeasuredWidthWithMargin(viewToMeasure);
         int childViewHeight = recyclerViewProxy.getMeasuredHeightWithMargin(viewToMeasure);
@@ -158,8 +157,6 @@ class DiscreteScrollLayoutManager extends RecyclerView.LayoutManager {
                 childViewHeight);
 
         extraLayoutSpace = scrollToChangeCurrent * offscreenItems;
-
-        recyclerViewProxy.detachAndScrapView(viewToMeasure, recycler);
     }
 
     protected void updateRecyclerDimensions(RecyclerView.State state) {
@@ -169,7 +166,6 @@ class DiscreteScrollLayoutManager extends RecyclerView.LayoutManager {
         if (dimensionsChanged) {
             viewWidth = recyclerViewProxy.getWidth();
             viewHeight = recyclerViewProxy.getHeight();
-            recyclerViewProxy.removeAllViews();
         }
         recyclerCenter.set(
                 recyclerViewProxy.getWidth() / 2,
@@ -224,7 +220,7 @@ class DiscreteScrollLayoutManager extends RecyclerView.LayoutManager {
         if (position < 0) return;
         View v = detachedCache.get(position);
         if (v == null) {
-            v = recyclerViewProxy.getMeasuredChildForAdapterPosition(position, recycler);
+            v = recyclerViewProxy.addMeasuredChildForAdapterPosition(position, recycler);
             recyclerViewProxy.layoutDecoratedWithMargins(v,
                     viewCenter.x - childHalfWidth, viewCenter.y - childHalfHeight,
                     viewCenter.x + childHalfWidth, viewCenter.y + childHalfHeight);

--- a/library/src/main/java/com/yarolegovich/discretescrollview/RecyclerViewProxy.java
+++ b/library/src/main/java/com/yarolegovich/discretescrollview/RecyclerViewProxy.java
@@ -1,7 +1,6 @@
 package com.yarolegovich.discretescrollview;
 
 import android.support.annotation.NonNull;
-import android.support.v7.widget.LinearSmoothScroller;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
@@ -49,9 +48,18 @@ public class RecyclerViewProxy {
         return layoutManager.getItemCount();
     }
 
-    public View getMeasuredChildForAdapterPosition(int position, RecyclerView.Recycler recycler) {
+    public View addMeasuredChildForAdapterPosition(int position, RecyclerView.Recycler recycler) {
         View view = recycler.getViewForPosition(position);
         layoutManager.addView(view);
+        layoutManager.measureChildWithMargins(view, 0, 0);
+        return view;
+    }
+
+    public View getMeasuredChildForAdapterPosition(int position, RecyclerView.Recycler recycler) {
+        View view = layoutManager.findViewByPosition(position);
+        if (view == null) {
+            view = recycler.getViewForPosition(position);
+        }
         layoutManager.measureChildWithMargins(view, 0, 0);
         return view;
     }

--- a/library/src/test/java/com/yarolegovich/discretescrollview/stub/StubRecyclerViewProxy.java
+++ b/library/src/test/java/com/yarolegovich/discretescrollview/stub/StubRecyclerViewProxy.java
@@ -46,6 +46,14 @@ public class StubRecyclerViewProxy extends RecyclerViewProxy {
     }
 
     @Override
+    public View addMeasuredChildForAdapterPosition(int position, RecyclerView.Recycler recycler) {
+        if (position < adapterItemCount) {
+            return new StubChildInfo(0, position).view;
+        }
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public View getMeasuredChildForAdapterPosition(int position, RecyclerView.Recycler recycler) {
         if (position < adapterItemCount) {
             return new StubChildInfo(0, position).view;


### PR DESCRIPTION
When DiscreteScrollView's size changes all views become removed. It causes all views inflation when layouting next time. Critically affects performance when you need to animate recycler size.